### PR TITLE
Normal collection test no longer fails randomly due to no-guarantee orde...

### DIFF
--- a/rethinkORM/tests/test_collection.py
+++ b/rethinkORM/tests/test_collection.py
@@ -10,18 +10,17 @@ class baseCollection_test(object):
     def normalCollection_test(self):
         one = gateModel.create(**baseData)
         two = gateModel.create(**newData)
-        parts = [two, one]
+
+        record_ids = [one.id, two.id]
 
         collection = RethinkCollection(gateModel)
 
         results = collection.fetch()
         assert len(results) == 2
-        for model in range(len(results)):
-            bit = parts[model]
-            model = results[model]
 
-            assert model.id == bit.id
-            assert model.what == bit.what
+        result_ids = [model.id for model in results]
+        for record_id in record_ids:
+            assert record_id in result_ids
 
         one.delete()
         two.delete()


### PR DESCRIPTION
RethinkDB does not guarantee ordering without using an order_by statement. So using straight comparison of lists to verify collection functionality fails inconsistently. Changed this to simply verify the existence of each record in the results. This merely compares IDs as these should be unique and property/field comparison should be covered in model tests.
